### PR TITLE
Fix "UUID is not json serializable" error

### DIFF
--- a/server.py
+++ b/server.py
@@ -372,14 +372,12 @@ class CreateFeatureMultipart(Resource):
             feature = None
         if not isinstance(feature, dict):
             api.abort(400, "feature is not an object")
-
         # Validate attachments
         attachments = attachments_service_handler()
         for key in request.files:
             filedata = request.files[key]
             if not attachments.validate_attachment(dataset, filedata):
                 api.abort(404, "Attachment validation failed: " + key)
-
         # Save attachments
         saved_attachments = {}
         for key in request.files:
@@ -393,7 +391,6 @@ class CreateFeatureMultipart(Resource):
                 saved_attachments[key] = slug
                 field = key.lstrip("file:")
                 feature["properties"][field] = "attachment://" + slug
-
         data_service = data_service_handler()
         result = data_service.create(
             get_jwt_identity(), dataset, feature)
@@ -755,7 +752,11 @@ class KeyValues(Resource):
             )
             if 'feature_collection' in result:
                 for feature in result['feature_collection']['features']:
-                    record = {"key": feature["id"] if key_field_name == "id" else feature['properties'][key_field_name], "value": feature['properties'][value_field_name].strip()}
+                    key = feature["id"] if key_field_name == "id" else feature['properties'][key_field_name]
+                    if type(key) == UUID:
+                        key = str(key)
+                    value = feature['properties'][value_field_name].strip()
+                    record = {"key": key, "value": value}
                     ret[table].append(record)
         return {"keyvalues": ret}
 

--- a/server.py
+++ b/server.py
@@ -372,12 +372,14 @@ class CreateFeatureMultipart(Resource):
             feature = None
         if not isinstance(feature, dict):
             api.abort(400, "feature is not an object")
+
         # Validate attachments
         attachments = attachments_service_handler()
         for key in request.files:
             filedata = request.files[key]
             if not attachments.validate_attachment(dataset, filedata):
                 api.abort(404, "Attachment validation failed: " + key)
+
         # Save attachments
         saved_attachments = {}
         for key in request.files:
@@ -391,6 +393,7 @@ class CreateFeatureMultipart(Resource):
                 saved_attachments[key] = slug
                 field = key.lstrip("file:")
                 feature["properties"][field] = "attachment://" + slug
+
         data_service = data_service_handler()
         result = data_service.create(
             get_jwt_identity(), dataset, feature)


### PR DESCRIPTION
Having an id field with type UUID causes a "UUID is not json serializable" error. 
This patch fixes this error by casting the UUID to string.

Let me know if you think a different approach should be used.