### PR TITLE
Update flask-jwt-extended version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask==1.1.2
-Flask-JWT-Extended==3.24.1
+Flask-JWT-Extended==3.25.0
 flask_login==0.5.0
 flask-restx==0.2.0
 psycopg2-binary==2.8.5


### PR DESCRIPTION
I'm having errors with token validation using the previous `flask-jwt-extended` version with `auth.get_auth_user()`. 

With the current version everything works as expected.