### PR TITLE
Support other types of IDs

### DIFF
--- a/server.py
+++ b/server.py
@@ -192,8 +192,8 @@ geojson_feature_request = create_model(api, 'Input Feature', [
 geojson_feature_member = create_model(api, 'Member Feature', [
     ['type', fields.String(required=True, description='Feature',
                            example='Feature')],
-    ['id', fields.Integer(required=True, description='Feature ID',
-                          example=123)],
+    ['id', fields.String(required=True, description='Feature ID',
+                         example=123)],
     ['geometry', fields.Nested(geojson_geometry, required=False,
                                allow_null=True,
                                description='Feature geometry')],
@@ -405,7 +405,7 @@ class CreateFeatureMultipart(Resource):
             api.abort(error_code, result['error'], **error_details)
 
 
-@api.route('/<path:dataset>/multipart/<int:id>')
+@api.route('/<path:dataset>/multipart/id')
 @api.response(404, 'Dataset or feature not found or permission error')
 @api.param('dataset', 'Dataset ID', default='qwc_demo.edit_points')
 @api.param('id', 'Feature ID')
@@ -475,7 +475,7 @@ class EditFeatureMultipart(Resource):
             api.abort(error_code, result['error'], **error_details)
 
 
-@api.route('/<path:dataset>/<int:id>')
+@api.route('/<path:dataset>/id')
 @api.response(404, 'Dataset or feature not found or permission error')
 @api.param('dataset', 'Dataset ID', default='qwc_demo.edit_points')
 @api.param('id', 'Feature ID')
@@ -574,7 +574,7 @@ class AttachmentDownloader(Resource):
         return send_file(path, as_attachment=True, attachment_filename=os.path.basename(path))
 
 
-@api.route('/<path:dataset>/<int:id>/relations')
+@api.route('/<path:dataset>/id/relations')
 @api.response(404, 'Dataset or feature not found or permission error')
 @api.param('dataset', 'Dataset ID', default='qwc_demo.edit_points')
 @api.param('id', 'Feature ID')

--- a/server.py
+++ b/server.py
@@ -279,7 +279,7 @@ post_relations_parser.add_argument(
 
 
 # routes
-@api.route('/<dataset>/')
+@api.route('/<path:dataset>/')
 @api.response(400, 'Bad request')
 @api.response(404, 'Dataset not found or permission error')
 @api.param('dataset', 'Dataset ID', default='qwc_demo.edit_points')
@@ -346,7 +346,7 @@ class DataCollection(Resource):
             api.abort(400, "Request data is not JSON")
 
 
-@api.route('/<dataset>/multipart')
+@api.route('/<path:dataset>/multipart')
 @api.response(400, 'Bad request')
 @api.response(404, 'Dataset not found or permission error')
 @api.param('dataset', 'Dataset ID', default='qwc_demo.edit_points')
@@ -405,7 +405,7 @@ class CreateFeatureMultipart(Resource):
             api.abort(error_code, result['error'], **error_details)
 
 
-@api.route('/<dataset>/multipart/<int:id>')
+@api.route('/<path:dataset>/multipart/<int:id>')
 @api.response(404, 'Dataset or feature not found or permission error')
 @api.param('dataset', 'Dataset ID', default='qwc_demo.edit_points')
 @api.param('id', 'Feature ID')
@@ -475,7 +475,7 @@ class EditFeatureMultipart(Resource):
             api.abort(error_code, result['error'], **error_details)
 
 
-@api.route('/<dataset>/<int:id>')
+@api.route('/<path:dataset>/<int:id>')
 @api.response(404, 'Dataset or feature not found or permission error')
 @api.param('dataset', 'Dataset ID', default='qwc_demo.edit_points')
 @api.param('id', 'Feature ID')
@@ -557,7 +557,7 @@ class DataMember(Resource):
             api.abort(error_code, result['error'])
 
 
-@api.route('/<dataset>/attachment')
+@api.route('/<path:dataset>/attachment')
 @api.response(404, 'Dataset or feature not found or permission error')
 @api.param('dataset', 'Dataset ID', default='qwc_demo.edit_points')
 class AttachmentDownloader(Resource):
@@ -574,7 +574,7 @@ class AttachmentDownloader(Resource):
         return send_file(path, as_attachment=True, attachment_filename=os.path.basename(path))
 
 
-@api.route('/<dataset>/<int:id>/relations')
+@api.route('/<path:dataset>/<int:id>/relations')
 @api.response(404, 'Dataset or feature not found or permission error')
 @api.param('dataset', 'Dataset ID', default='qwc_demo.edit_points')
 @api.param('id', 'Feature ID')


### PR DESCRIPTION
This already includes #9 because the changes are almost all on the same rows.

If the feature's `id` is defined as string and not forced to be integer, it is possible to also use UUIDs primary keys as well as integer ones.

Another possibility would be to create multiple routes, for int and UUID, but, IMHO, it would create unnecessary duplications.